### PR TITLE
Self hosted runner fixes and retries for starting binary

### DIFF
--- a/setup-local/.eslintrc.js
+++ b/setup-local/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     'prefer-destructuring': ['error', { object: true, array: false }],
     'no-restricted-syntax': 'off',
     'linebreak-style': 'off',
+    'no-plusplus': 'off',
   },
   ignorePatterns: ['dist/index.js'],
 };

--- a/setup-local/config/constants.js
+++ b/setup-local/config/constants.js
@@ -50,6 +50,7 @@ module.exports = {
   },
 
   BINARY_MAX_TRIES: 3,
+  RETRY_DELAY_BINARY: 5000,
 
   RESTRICTED_LOCAL_ARGS: ['k', 'key', 'local-identifier', 'daemon', 'only-automate', 'verbose', 'log-file', 'ci-plugin'],
 

--- a/setup-local/config/constants.js
+++ b/setup-local/config/constants.js
@@ -55,5 +55,6 @@ module.exports = {
 
   LOCAL_BINARY_FOLDER: 'LocalBinaryFolder',
   LOCAL_BINARY_NAME: 'BrowserStackLocal',
+  LOCAL_BINARY_ZIP: 'binaryZip',
   LOCAL_LOG_FILE_PREFIX: 'BrowserStackLocal',
 };

--- a/setup-local/config/constants.js
+++ b/setup-local/config/constants.js
@@ -49,7 +49,7 @@ module.exports = {
     },
   },
 
-  BINARY_MAX_TRIES: 2,
+  BINARY_MAX_TRIES: 3,
 
   RESTRICTED_LOCAL_ARGS: ['k', 'key', 'local-identifier', 'daemon', 'only-automate', 'verbose', 'log-file', 'ci-plugin'],
 

--- a/setup-local/config/constants.js
+++ b/setup-local/config/constants.js
@@ -49,6 +49,8 @@ module.exports = {
     },
   },
 
+  BINARY_MAX_TRIES: 2,
+
   RESTRICTED_LOCAL_ARGS: ['k', 'key', 'local-identifier', 'daemon', 'only-automate', 'verbose', 'log-file', 'ci-plugin'],
 
   LOCAL_BINARY_FOLDER: 'LocalBinaryFolder',

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1111,15 +1111,15 @@ class BinaryControl {
     switch (this.platform) {
       case PLATFORMS.DARWIN:
         this.binaryLink = BINARY_LINKS.DARWIN;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.LINUX:
         this.binaryLink = os.arch() === 'x32' ? BINARY_LINKS.LINUX_32 : BINARY_LINKS.LINUX_64;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.WIN32:
         this.binaryLink = BINARY_LINKS.WINDOWS;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       default:
         throw Error(`Unsupported Platform: ${this.platform}. No BrowserStackLocal binary found.`);

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1192,20 +1192,20 @@ class BinaryControl {
   async _triggerBinary(operation) {
     let triggerOutput = '';
     let triggerError = '';
-    await exec.exec(
-      `${LOCAL_BINARY_NAME} ${this.binaryArgs} --daemon ${operation}`,
-      [],
-      {
-        listeners: {
-          stdout: (data) => {
-            triggerOutput += data.toString();
-          },
-          stderr: (data) => {
-            triggerError += data.toString();
-          },
-        },
-      },
-    );
+    // await exec.exec(
+    //   `${LOCAL_BINARY_NAME} ${this.binaryArgs} --daemon ${operation}`,
+    //   [],
+    //   {
+    //     listeners: {
+    //       stdout: (data) => {
+    //         triggerOutput += data.toString();
+    //       },
+    //       stderr: (data) => {
+    //         triggerError += data.toString();
+    //       },
+    //     },
+    //   },
+    // );
 
     return {
       output: triggerOutput,

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1208,6 +1208,15 @@ class BinaryControl {
     };
   }
 
+  async _removeAnyStaleBinary() {
+    const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
+    const previousLocalBinary = path.resolve(
+      this.binaryFolder,
+      `${LOCAL_BINARY_NAME}${this.platform === PLATFORMS.WIN32 ? '.exe' : ''}`,
+    );
+    await Promise.all([io.rmRF(binaryZip), io.rmRF(previousLocalBinary)]);
+  }
+
   /**
    * Downloads the Local Binary, extracts it and adds it in the PATH variable
    */
@@ -1217,22 +1226,17 @@ class BinaryControl {
       core.info('BrowserStackLocal binary already exists in cache. Using that instead of downloading again...');
       // A cached tool is persisted across runs. But the PATH is reset back to its original
       // state between each run. Thus, adding the cached tool path back to PATH again.
-      // core.addPath(cachedBinaryPath);
-      // return;
+      core.addPath(cachedBinaryPath);
+      return;
     }
 
     try {
       await this._makeDirectory();
-      core.info('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary from the download path...');
-      const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
-      const previousLocalBinary = path.resolve(
-        this.binaryFolder,
-        `${LOCAL_BINARY_NAME}${this.platform === PLATFORMS.WIN32 ? '.exe' : ''}`
-      );
-      await Promise.all([io.rmRF(binaryZip), io.rmRF(previousLocalBinary)]);
+      core.debug('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary before downloading...');
+      this._removeAnyStaleBinary();
 
       core.info('Downloading BrowserStackLocal binary...');
-      const downloadPath = await tc.downloadTool(this.binaryLink, binaryZip);
+      const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
@@ -1272,7 +1276,7 @@ class BinaryControl {
         }
       } catch (e) {
         if (triesAvailable) {
-          core.info(`Error in starting local tunnel: ${e.message}. Trying again in 5 seconds...`);
+          core.debug(`Error in starting local tunnel: ${e.message}. Trying again in 5 seconds...`);
           // eslint-disable-next-line no-await-in-loop
           await Utils.sleepFor(5000);
         } else {
@@ -7262,7 +7266,9 @@ class Utils {
   }
 
   static async sleepFor(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    let parsedMilliseconds = parseFloat(ms);
+    parsedMilliseconds = parsedMilliseconds > 0 ? parsedMilliseconds : 0;
+    return new Promise((resolve) => setTimeout(resolve, parsedMilliseconds));
   }
 }
 

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1238,7 +1238,7 @@ class BinaryControl {
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
       // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
-      core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
+      // core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
       // core.addPath(cachedPath);
     } catch (e) {

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1192,20 +1192,20 @@ class BinaryControl {
   async _triggerBinary(operation) {
     let triggerOutput = '';
     let triggerError = '';
-    // await exec.exec(
-    //   `${LOCAL_BINARY_NAME} ${this.binaryArgs} --daemon ${operation}`,
-    //   [],
-    //   {
-    //     listeners: {
-    //       stdout: (data) => {
-    //         triggerOutput += data.toString();
-    //       },
-    //       stderr: (data) => {
-    //         triggerError += data.toString();
-    //       },
-    //     },
-    //   },
-    // );
+    await exec.exec(
+      `${LOCAL_BINARY_NAME} ${this.binaryArgs} --daemon ${operation}`,
+      [],
+      {
+        listeners: {
+          stdout: (data) => {
+            triggerOutput += data.toString();
+          },
+          stderr: (data) => {
+            triggerError += data.toString();
+          },
+        },
+      },
+    );
 
     return {
       output: triggerOutput,

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1237,6 +1237,7 @@ class BinaryControl {
 
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
+      core.info(`Downloaded Path: ${downloadPath}`);
       // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       // core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1218,7 +1218,9 @@ class BinaryControl {
     try {
       await this._makeDirectory();
       core.info('Downloading BrowserStackLocal binary...');
-      const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
+      const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
+      await io.rmRF(binaryZip);
+      const downloadPath = await tc.downloadTool(this.binaryLink, binaryZip);
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1233,7 +1233,7 @@ class BinaryControl {
     try {
       await this._makeDirectory();
       core.debug('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary before downloading...');
-      // this._removeAnyStaleBinary();
+      this._removeAnyStaleBinary();
 
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -13489,7 +13489,7 @@ module.exports = {
     },
   },
 
-  BINARY_MAX_TRIES: 2,
+  BINARY_MAX_TRIES: 3,
 
   RESTRICTED_LOCAL_ARGS: ['k', 'key', 'local-identifier', 'daemon', 'only-automate', 'verbose', 'log-file', 'ci-plugin'],
 

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1083,6 +1083,7 @@ const {
   LOCAL_BINARY_ZIP,
   LOCAL_LOG_FILE_PREFIX,
   LOCAL_BINARY_TRIGGER,
+  RETRY_DELAY_BINARY,
   BINARY_MAX_TRIES,
   ALLOWED_INPUT_VALUES: {
     LOCAL_TESTING,
@@ -1286,7 +1287,7 @@ class BinaryControl {
         if (triesAvailable) {
           core.info(`Error in starting local tunnel: ${e.message}. Trying again in 5 seconds...`);
           // eslint-disable-next-line no-await-in-loop
-          await Utils.sleepFor(5000);
+          await Utils.sleepFor(RETRY_DELAY_BINARY);
         } else {
           throw Error(`Local tunnel could not be started. Error message from binary: ${e.message}`);
         }
@@ -13489,6 +13490,7 @@ module.exports = {
   },
 
   BINARY_MAX_TRIES: 3,
+  RETRY_DELAY_BINARY: 5000,
 
   RESTRICTED_LOCAL_ARGS: ['k', 'key', 'local-identifier', 'daemon', 'only-automate', 'verbose', 'log-file', 'ci-plugin'],
 

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1239,7 +1239,7 @@ class BinaryControl {
     try {
       await this._makeDirectory();
       core.debug('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary before downloading...');
-      this._removeAnyStaleBinary();
+      await this._removeAnyStaleBinary();
 
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(
@@ -1259,6 +1259,7 @@ class BinaryControl {
    * Starts Local Binary using the args generated for this action
    */
   async startBinary() {
+    this._generateArgsForBinary();
     let { localIdentifier } = this.stateForBinary;
     localIdentifier = localIdentifier ? `with local-identifier=${localIdentifier}` : '';
     core.info(`Starting local tunnel ${localIdentifier} in daemon mode...`);
@@ -1267,8 +1268,6 @@ class BinaryControl {
 
     while (triesAvailable--) {
       try {
-        this._generateArgsForBinary();
-
         // eslint-disable-next-line no-await-in-loop
         const { output, error } = await this._triggerBinary(LOCAL_TESTING.START);
 
@@ -1299,8 +1298,8 @@ class BinaryControl {
    * Stops Local Binary using the args generated for this action
    */
   async stopBinary() {
+    this._generateArgsForBinary();
     try {
-      this._generateArgsForBinary();
       let { localIdentifier } = this.stateForBinary;
       localIdentifier = localIdentifier ? `with local-identifier=${localIdentifier}` : '';
       core.info(`Stopping local tunnel ${localIdentifier} in daemon mode...`);

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1108,7 +1108,6 @@ class BinaryControl {
    * platform and the architecture
    */
   _decidePlatformAndBinary() {
-    core.info(`GITHUB WORKSPACE CHECK: ${process.env.GITHUB_WORKSPACE}`);
     this.binaryFolder = path.resolve(
       process.env.GITHUB_WORKSPACE,
       '..', '..', '..',
@@ -1243,7 +1242,6 @@ class BinaryControl {
 
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
-      core.info(`Downloaded Path: ${downloadPath}`);
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1080,6 +1080,7 @@ const {
   LOCAL_BINARY_FOLDER,
   PLATFORMS,
   LOCAL_BINARY_NAME,
+  LOCAL_BINARY_ZIP,
   LOCAL_LOG_FILE_PREFIX,
   LOCAL_BINARY_TRIGGER,
   BINARY_MAX_TRIES,
@@ -1214,7 +1215,7 @@ class BinaryControl {
   }
 
   async _removeAnyStaleBinary() {
-    const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
+    const binaryZip = path.resolve(this.binaryFolder, LOCAL_BINARY_ZIP);
     const previousLocalBinary = path.resolve(
       this.binaryFolder,
       `${LOCAL_BINARY_NAME}${this.platform === PLATFORMS.WIN32 ? '.exe' : ''}`,
@@ -1241,7 +1242,10 @@ class BinaryControl {
       this._removeAnyStaleBinary();
 
       core.info('Downloading BrowserStackLocal binary...');
-      const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
+      const downloadPath = await tc.downloadTool(
+        this.binaryLink,
+        path.resolve(this.binaryFolder, LOCAL_BINARY_ZIP),
+      );
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
@@ -13491,6 +13495,7 @@ module.exports = {
 
   LOCAL_BINARY_FOLDER: 'LocalBinaryFolder',
   LOCAL_BINARY_NAME: 'BrowserStackLocal',
+  LOCAL_BINARY_ZIP: 'binaryZip',
   LOCAL_LOG_FILE_PREFIX: 'BrowserStackLocal',
 };
 

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1214,6 +1214,8 @@ class BinaryControl {
     const cachedBinaryPath = Utils.checkToolInCache(LOCAL_BINARY_NAME, '1.0.0');
     if (cachedBinaryPath) {
       core.info('BrowserStackLocal binary already exists in cache. Using that instead of downloading again...');
+      // A cached tool is persisted across runs. But the PATH is reset back to its original
+      // between each run. Thus, adding the cached tool path back to PATH again
       core.addPath(cachedBinaryPath);
       return;
     }
@@ -1239,7 +1241,7 @@ class BinaryControl {
   /**
    * Starts Local Binary using the args generated for this action
    */
-  async startBinary() {
+  async startBinary(retry = 1) {
     try {
       this._generateArgsForBinary();
       let { localIdentifier } = this.stateForBinary;
@@ -1259,7 +1261,12 @@ class BinaryControl {
         throw Error(JSON.stringify(error));
       }
     } catch (e) {
-      throw Error(`Local tunnel could not be started. Error message from binary: ${e.message}`);
+      if (retry) {
+        core.info(`Error in starting local tunnel. Trying again...`);
+        await this.startBinary(retry - 1);
+      } else {
+        throw Error(`Local tunnel could not be started. Error message from binary: ${e.message}`);
+      }
     }
   }
 
@@ -7239,8 +7246,6 @@ class Utils {
 
   static checkToolInCache(toolName, version) {
     const toolCachePath = tc.find(toolName, version);
-    console.dir(process.env.PATH);
-    console.dir(toolCachePath);
     return toolCachePath;
   }
 }

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -7240,7 +7240,7 @@ class Utils {
   static checkToolInCache(toolName, version) {
     const toolCachePath = tc.find(toolName, version);
     console.dir(process.env.PATH);
-    console.dir(toolCache);
+    console.dir(toolCachePath);
     return toolCachePath;
   }
 }

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1245,8 +1245,8 @@ class BinaryControl {
       core.info(`Downloaded Path: ${downloadPath}`);
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
-      // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
-      // core.addPath(cachedPath);
+      const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
+      core.addPath(cachedPath);
     } catch (e) {
       throw Error(`BrowserStackLocal binary could not be downloaded due to ${e.message}`);
     }

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1238,8 +1238,8 @@ class BinaryControl {
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
       core.info(`Downloaded Path: ${downloadPath}`);
-      const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
-      core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
+      // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
+      // core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
       // core.addPath(cachedPath);
     } catch (e) {

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -7237,6 +7237,7 @@ class Utils {
 
   static checkToolInCache(toolName) {
     const toolCache = tc.findAllVersions(toolName);
+    console.dir(process.env.PATH);
     console.dir(toolCache);
     return toolCache.length !== 0;
   }

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1217,9 +1217,10 @@ class BinaryControl {
     }
     try {
       await this._makeDirectory();
-      core.info('Downloading BrowserStackLocal binary...');
+      core.info('Deleting any existing partially downloaded binary...');
       const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
       await io.rmRF(binaryZip);
+      core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, binaryZip);
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1082,6 +1082,7 @@ const {
   LOCAL_BINARY_NAME,
   LOCAL_LOG_FILE_PREFIX,
   LOCAL_BINARY_TRIGGER,
+  BINARY_MAX_TRIES,
   ALLOWED_INPUT_VALUES: {
     LOCAL_TESTING,
   },
@@ -1215,7 +1216,7 @@ class BinaryControl {
     if (cachedBinaryPath) {
       core.info('BrowserStackLocal binary already exists in cache. Using that instead of downloading again...');
       // A cached tool is persisted across runs. But the PATH is reset back to its original
-      // between each run. Thus, adding the cached tool path back to PATH again
+      // state between each run. Thus, adding the cached tool path back to PATH again.
       core.addPath(cachedBinaryPath);
       return;
     }
@@ -1241,31 +1242,37 @@ class BinaryControl {
   /**
    * Starts Local Binary using the args generated for this action
    */
-  async startBinary(retry = 1) {
-    try {
-      this._generateArgsForBinary();
-      let { localIdentifier } = this.stateForBinary;
-      localIdentifier = localIdentifier ? `with local-identifier=${localIdentifier}` : '';
-      core.info(`Starting local tunnel ${localIdentifier} in daemon mode...`);
+  async startBinary() {
+    let { localIdentifier } = this.stateForBinary;
+    localIdentifier = localIdentifier ? `with local-identifier=${localIdentifier}` : '';
+    core.info(`Starting local tunnel ${localIdentifier} in daemon mode...`);
 
-      const { output, error } = await this._triggerBinary(LOCAL_TESTING.START);
+    let triesAvailable = BINARY_MAX_TRIES;
 
-      if (!error) {
-        const outputParsed = JSON.parse(output);
-        if (outputParsed.state === LOCAL_BINARY_TRIGGER.START.CONNECTED) {
-          core.info(`Local tunnel status: ${outputParsed.message}`);
-        } else {
+    while (triesAvailable--) {
+      try {
+        this._generateArgsForBinary();
+
+        // eslint-disable-next-line no-await-in-loop
+        const { output, error } = await this._triggerBinary(LOCAL_TESTING.START);
+
+        if (!error) {
+          const outputParsed = JSON.parse(output);
+          if (outputParsed.state === LOCAL_BINARY_TRIGGER.START.CONNECTED) {
+            core.info(`Local tunnel status: ${outputParsed.message}`);
+            return;
+          }
+
           throw Error(JSON.stringify(outputParsed.message));
+        } else {
+          throw Error(JSON.stringify(error));
         }
-      } else {
-        throw Error(JSON.stringify(error));
-      }
-    } catch (e) {
-      if (retry) {
-        core.info(`Error in starting local tunnel. Trying again...`);
-        await this.startBinary(retry - 1);
-      } else {
-        throw Error(`Local tunnel could not be started. Error message from binary: ${e.message}`);
+      } catch (e) {
+        if (triesAvailable) {
+          core.info(`Error in starting local tunnel: ${e.message}. Trying again...`);
+        } else {
+          throw Error(`Local tunnel could not be started. Error message from binary: ${e.message}`);
+        }
       }
     }
   }
@@ -13457,6 +13464,8 @@ module.exports = {
       SUCCESS: 'success',
     },
   },
+
+  BINARY_MAX_TRIES: 2,
 
   RESTRICTED_LOCAL_ARGS: ['k', 'key', 'local-identifier', 'daemon', 'only-automate', 'verbose', 'log-file', 'ci-plugin'],
 

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1211,10 +1211,13 @@ class BinaryControl {
    * Downloads the Local Binary, extracts it and adds it in the PATH variable
    */
   async downloadBinary() {
-    if (Utils.checkToolInCache(LOCAL_BINARY_NAME)) {
+    const cachedBinaryPath = Utils.checkToolInCache(LOCAL_BINARY_NAME, '1.0.0');
+    if (cachedBinaryPath) {
       core.info('BrowserStackLocal binary already exists in cache. Using that instead of downloading again...');
-      // return;
+      core.addPath(cachedBinaryPath);
+      return;
     }
+
     try {
       await this._makeDirectory();
       core.info('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary from the download path...');
@@ -1228,7 +1231,6 @@ class BinaryControl {
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
       core.addPath(cachedPath);
-      this.binaryPath = extractedPath;
     } catch (e) {
       throw Error(`BrowserStackLocal binary could not be downloaded due to ${e.message}`);
     }
@@ -7235,11 +7237,11 @@ class Utils {
     delete process.env[environmentVariable];
   }
 
-  static checkToolInCache(toolName) {
-    const toolCache = tc.findAllVersions(toolName);
+  static checkToolInCache(toolName, version) {
+    const toolCachePath = tc.find(toolName, version);
     console.dir(process.env.PATH);
     console.dir(toolCache);
-    return toolCache.length !== 0;
+    return toolCachePath;
   }
 }
 

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1108,6 +1108,7 @@ class BinaryControl {
    * platform and the architecture
    */
   _decidePlatformAndBinary() {
+    core.info(`GITHUB WORKSPACE CHECK: ${process.env.GITHUB_WORKSPACE}`);
     this.binaryFolder = path.resolve(
       process.env.GITHUB_WORKSPACE,
       '..', '..', '..',

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1108,7 +1108,6 @@ class BinaryControl {
    * platform and the architecture
    */
   _decidePlatformAndBinary() {
-    core.info(`GITHUB WORKSPACE CHECK: ${process.env.GITHUB_WORKSPACE}`);
     this.binaryFolder = path.resolve(
       process.env.GITHUB_WORKSPACE,
       '..', '..', '..',

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1233,14 +1233,14 @@ class BinaryControl {
     try {
       await this._makeDirectory();
       core.debug('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary before downloading...');
-      this._removeAnyStaleBinary();
+      // this._removeAnyStaleBinary();
 
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
-      const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
+      // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
-      const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
-      core.addPath(cachedPath);
+      // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
+      // core.addPath(cachedPath);
     } catch (e) {
       throw Error(`BrowserStackLocal binary could not be downloaded due to ${e.message}`);
     }
@@ -1276,7 +1276,7 @@ class BinaryControl {
         }
       } catch (e) {
         if (triesAvailable) {
-          core.debug(`Error in starting local tunnel: ${e.message}. Trying again in 5 seconds...`);
+          core.info(`Error in starting local tunnel: ${e.message}. Trying again in 5 seconds...`);
           // eslint-disable-next-line no-await-in-loop
           await Utils.sleepFor(5000);
         } else {

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1238,8 +1238,8 @@ class BinaryControl {
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
       core.info(`Downloaded Path: ${downloadPath}`);
-      // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
-      // core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
+      const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
+      core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
       // core.addPath(cachedPath);
     } catch (e) {

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1217,7 +1217,7 @@ class BinaryControl {
     }
     try {
       await this._makeDirectory();
-      core.info('Deleting any existing partially downloaded binary...');
+      core.info('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary from the download path...');
       const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
       const previousLocalBinary = path.resolve(this.binaryFolder, LOCAL_BINARY_NAME);
       await Promise.all([io.rmRF(binaryZip), io.rmRF(previousLocalBinary)]);

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1225,7 +1225,10 @@ class BinaryControl {
       await this._makeDirectory();
       core.info('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary from the download path...');
       const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
-      const previousLocalBinary = path.resolve(this.binaryFolder, LOCAL_BINARY_NAME);
+      const previousLocalBinary = path.resolve(
+        this.binaryFolder,
+        `${LOCAL_BINARY_NAME}${this.platform === PLATFORMS.WIN32 ? '.exe' : ''}`
+      );
       await Promise.all([io.rmRF(binaryZip), io.rmRF(previousLocalBinary)]);
 
       core.info('Downloading BrowserStackLocal binary...');

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1108,18 +1108,23 @@ class BinaryControl {
    * platform and the architecture
    */
   _decidePlatformAndBinary() {
+    this.binaryFolder = path.resolve(
+      process.env.GITHUB_WORKSPACE,
+      '..', '..', '..',
+      '_work',
+      'binary',
+      LOCAL_BINARY_FOLDER,
+      this.platform,
+    );
     switch (this.platform) {
       case PLATFORMS.DARWIN:
         this.binaryLink = BINARY_LINKS.DARWIN;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.LINUX:
         this.binaryLink = os.arch() === 'x32' ? BINARY_LINKS.LINUX_32 : BINARY_LINKS.LINUX_64;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.WIN32:
         this.binaryLink = BINARY_LINKS.WINDOWS;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       default:
         throw Error(`Unsupported Platform: ${this.platform}. No BrowserStackLocal binary found.`);
@@ -1238,8 +1243,8 @@ class BinaryControl {
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
       core.info(`Downloaded Path: ${downloadPath}`);
-      // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
-      // core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
+      const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
+      core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
       // core.addPath(cachedPath);
     } catch (e) {

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1217,8 +1217,8 @@ class BinaryControl {
       core.info('BrowserStackLocal binary already exists in cache. Using that instead of downloading again...');
       // A cached tool is persisted across runs. But the PATH is reset back to its original
       // state between each run. Thus, adding the cached tool path back to PATH again.
-      core.addPath(cachedBinaryPath);
-      return;
+      // core.addPath(cachedBinaryPath);
+      // return;
     }
 
     try {
@@ -1269,7 +1269,9 @@ class BinaryControl {
         }
       } catch (e) {
         if (triesAvailable) {
-          core.info(`Error in starting local tunnel: ${e.message}. Trying again...`);
+          core.info(`Error in starting local tunnel: ${e.message}. Trying again in 5 seconds...`);
+          // eslint-disable-next-line no-await-in-loop
+          await Utils.sleepFor(5000);
         } else {
           throw Error(`Local tunnel could not be started. Error message from binary: ${e.message}`);
         }
@@ -7254,6 +7256,10 @@ class Utils {
   static checkToolInCache(toolName, version) {
     const toolCachePath = tc.find(toolName, version);
     return toolCachePath;
+  }
+
+  static async sleepFor(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }
 

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1219,7 +1219,9 @@ class BinaryControl {
       await this._makeDirectory();
       core.info('Deleting any existing partially downloaded binary...');
       const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
-      await io.rmRF(binaryZip);
+      const previousLocalBinary = path.resolve(this.binaryFolder, LOCAL_BINARY_NAME);
+      await Promise.all([io.rmRF(binaryZip), io.rmRF(previousLocalBinary)]);
+
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, binaryZip);
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1213,7 +1213,7 @@ class BinaryControl {
   async downloadBinary() {
     if (Utils.checkToolInCache(LOCAL_BINARY_NAME)) {
       core.info('BrowserStackLocal binary already exists in cache. Using that instead of downloading again...');
-      return;
+      // return;
     }
     try {
       await this._makeDirectory();
@@ -7237,6 +7237,7 @@ class Utils {
 
   static checkToolInCache(toolName) {
     const toolCache = tc.findAllVersions(toolName);
+    console.dir(toolCache);
     return toolCache.length !== 0;
   }
 }

--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1111,15 +1111,15 @@ class BinaryControl {
     switch (this.platform) {
       case PLATFORMS.DARWIN:
         this.binaryLink = BINARY_LINKS.DARWIN;
-        this.binaryFolder = path.resolve(process.env.HOME, 'work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.LINUX:
         this.binaryLink = os.arch() === 'x32' ? BINARY_LINKS.LINUX_32 : BINARY_LINKS.LINUX_64;
-        this.binaryFolder = path.resolve(process.env.HOME, 'work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.WIN32:
         this.binaryLink = BINARY_LINKS.WINDOWS;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', 'work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       default:
         throw Error(`Unsupported Platform: ${this.platform}. No BrowserStackLocal binary found.`);

--- a/setup-local/package.json
+++ b/setup-local/package.json
@@ -10,7 +10,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run test && npm run build && git add dist/"
+      "pre-commit": ""
     }
   },
   "repository": {

--- a/setup-local/package.json
+++ b/setup-local/package.json
@@ -10,7 +10,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": ""
+      "pre-commit": "npm run test && npm run build && git add dist/"
     }
   },
   "repository": {

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -46,15 +46,15 @@ class BinaryControl {
     switch (this.platform) {
       case PLATFORMS.DARWIN:
         this.binaryLink = BINARY_LINKS.DARWIN;
-        this.binaryFolder = path.resolve(process.env.HOME, 'work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.LINUX:
         this.binaryLink = os.arch() === 'x32' ? BINARY_LINKS.LINUX_32 : BINARY_LINKS.LINUX_64;
-        this.binaryFolder = path.resolve(process.env.HOME, 'work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.WIN32:
         this.binaryLink = BINARY_LINKS.WINDOWS;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', 'work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       default:
         throw Error(`Unsupported Platform: ${this.platform}. No BrowserStackLocal binary found.`);

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -173,8 +173,8 @@ class BinaryControl {
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
       core.info(`Downloaded Path: ${downloadPath}`);
-      const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
-      core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
+      // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
+      // core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
       // core.addPath(cachedPath);
     } catch (e) {

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -43,7 +43,6 @@ class BinaryControl {
    * platform and the architecture
    */
   _decidePlatformAndBinary() {
-    core.info(`GITHUB WORKSPACE CHECK: ${process.env.GITHUB_WORKSPACE}`);
     this.binaryFolder = path.resolve(
       process.env.GITHUB_WORKSPACE,
       '..', '..', '..',

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -174,7 +174,7 @@ class BinaryControl {
     try {
       await this._makeDirectory();
       core.debug('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary before downloading...');
-      this._removeAnyStaleBinary();
+      await this._removeAnyStaleBinary();
 
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(
@@ -194,6 +194,7 @@ class BinaryControl {
    * Starts Local Binary using the args generated for this action
    */
   async startBinary() {
+    this._generateArgsForBinary();
     let { localIdentifier } = this.stateForBinary;
     localIdentifier = localIdentifier ? `with local-identifier=${localIdentifier}` : '';
     core.info(`Starting local tunnel ${localIdentifier} in daemon mode...`);
@@ -202,8 +203,6 @@ class BinaryControl {
 
     while (triesAvailable--) {
       try {
-        this._generateArgsForBinary();
-
         // eslint-disable-next-line no-await-in-loop
         const { output, error } = await this._triggerBinary(LOCAL_TESTING.START);
 
@@ -234,8 +233,8 @@ class BinaryControl {
    * Stops Local Binary using the args generated for this action
    */
   async stopBinary() {
+    this._generateArgsForBinary();
     try {
-      this._generateArgsForBinary();
       let { localIdentifier } = this.stateForBinary;
       localIdentifier = localIdentifier ? `with local-identifier=${localIdentifier}` : '';
       core.info(`Stopping local tunnel ${localIdentifier} in daemon mode...`);

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -43,6 +43,7 @@ class BinaryControl {
    * platform and the architecture
    */
   _decidePlatformAndBinary() {
+    core.info(`GITHUB WORKSPACE CHECK: ${process.env.GITHUB_WORKSPACE}`);
     this.binaryFolder = path.resolve(
       process.env.GITHUB_WORKSPACE,
       '..', '..', '..',

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -180,8 +180,8 @@ class BinaryControl {
       core.info(`Downloaded Path: ${downloadPath}`);
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
-      // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
-      // core.addPath(cachedPath);
+      const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
+      core.addPath(cachedPath);
     } catch (e) {
       throw Error(`BrowserStackLocal binary could not be downloaded due to ${e.message}`);
     }

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -148,7 +148,7 @@ class BinaryControl {
   async downloadBinary() {
     if (Utils.checkToolInCache(LOCAL_BINARY_NAME)) {
       core.info('BrowserStackLocal binary already exists in cache. Using that instead of downloading again...');
-      return;
+      // return;
     }
     try {
       await this._makeDirectory();

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -127,20 +127,20 @@ class BinaryControl {
   async _triggerBinary(operation) {
     let triggerOutput = '';
     let triggerError = '';
-    // await exec.exec(
-    //   `${LOCAL_BINARY_NAME} ${this.binaryArgs} --daemon ${operation}`,
-    //   [],
-    //   {
-    //     listeners: {
-    //       stdout: (data) => {
-    //         triggerOutput += data.toString();
-    //       },
-    //       stderr: (data) => {
-    //         triggerError += data.toString();
-    //       },
-    //     },
-    //   },
-    // );
+    await exec.exec(
+      `${LOCAL_BINARY_NAME} ${this.binaryArgs} --daemon ${operation}`,
+      [],
+      {
+        listeners: {
+          stdout: (data) => {
+            triggerOutput += data.toString();
+          },
+          stderr: (data) => {
+            triggerError += data.toString();
+          },
+        },
+      },
+    );
 
     return {
       output: triggerOutput,

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -168,14 +168,14 @@ class BinaryControl {
     try {
       await this._makeDirectory();
       core.debug('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary before downloading...');
-      this._removeAnyStaleBinary();
+      // this._removeAnyStaleBinary();
 
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
-      const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
+      // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
-      const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
-      core.addPath(cachedPath);
+      // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
+      // core.addPath(cachedPath);
     } catch (e) {
       throw Error(`BrowserStackLocal binary could not be downloaded due to ${e.message}`);
     }
@@ -211,7 +211,7 @@ class BinaryControl {
         }
       } catch (e) {
         if (triesAvailable) {
-          core.debug(`Error in starting local tunnel: ${e.message}. Trying again in 5 seconds...`);
+          core.info(`Error in starting local tunnel: ${e.message}. Trying again in 5 seconds...`);
           // eslint-disable-next-line no-await-in-loop
           await Utils.sleepFor(5000);
         } else {

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -172,6 +172,7 @@ class BinaryControl {
 
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
+      core.info(`Downloaded Path: ${downloadPath}`);
       // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       // core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -18,6 +18,7 @@ const {
   LOCAL_BINARY_ZIP,
   LOCAL_LOG_FILE_PREFIX,
   LOCAL_BINARY_TRIGGER,
+  RETRY_DELAY_BINARY,
   BINARY_MAX_TRIES,
   ALLOWED_INPUT_VALUES: {
     LOCAL_TESTING,
@@ -221,7 +222,7 @@ class BinaryControl {
         if (triesAvailable) {
           core.info(`Error in starting local tunnel: ${e.message}. Trying again in 5 seconds...`);
           // eslint-disable-next-line no-await-in-loop
-          await Utils.sleepFor(5000);
+          await Utils.sleepFor(RETRY_DELAY_BINARY);
         } else {
           throw Error(`Local tunnel could not be started. Error message from binary: ${e.message}`);
         }

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -17,6 +17,7 @@ const {
   LOCAL_BINARY_NAME,
   LOCAL_LOG_FILE_PREFIX,
   LOCAL_BINARY_TRIGGER,
+  BINARY_MAX_TRIES,
   ALLOWED_INPUT_VALUES: {
     LOCAL_TESTING,
   },
@@ -150,7 +151,7 @@ class BinaryControl {
     if (cachedBinaryPath) {
       core.info('BrowserStackLocal binary already exists in cache. Using that instead of downloading again...');
       // A cached tool is persisted across runs. But the PATH is reset back to its original
-      // between each run. Thus, adding the cached tool path back to PATH again
+      // state between each run. Thus, adding the cached tool path back to PATH again.
       core.addPath(cachedBinaryPath);
       return;
     }
@@ -176,31 +177,37 @@ class BinaryControl {
   /**
    * Starts Local Binary using the args generated for this action
    */
-  async startBinary(retry = 1) {
-    try {
-      this._generateArgsForBinary();
-      let { localIdentifier } = this.stateForBinary;
-      localIdentifier = localIdentifier ? `with local-identifier=${localIdentifier}` : '';
-      core.info(`Starting local tunnel ${localIdentifier} in daemon mode...`);
+  async startBinary() {
+    let { localIdentifier } = this.stateForBinary;
+    localIdentifier = localIdentifier ? `with local-identifier=${localIdentifier}` : '';
+    core.info(`Starting local tunnel ${localIdentifier} in daemon mode...`);
 
-      const { output, error } = await this._triggerBinary(LOCAL_TESTING.START);
+    let triesAvailable = BINARY_MAX_TRIES;
 
-      if (!error) {
-        const outputParsed = JSON.parse(output);
-        if (outputParsed.state === LOCAL_BINARY_TRIGGER.START.CONNECTED) {
-          core.info(`Local tunnel status: ${outputParsed.message}`);
-        } else {
+    while (triesAvailable--) {
+      try {
+        this._generateArgsForBinary();
+
+        // eslint-disable-next-line no-await-in-loop
+        const { output, error } = await this._triggerBinary(LOCAL_TESTING.START);
+
+        if (!error) {
+          const outputParsed = JSON.parse(output);
+          if (outputParsed.state === LOCAL_BINARY_TRIGGER.START.CONNECTED) {
+            core.info(`Local tunnel status: ${outputParsed.message}`);
+            return;
+          }
+
           throw Error(JSON.stringify(outputParsed.message));
+        } else {
+          throw Error(JSON.stringify(error));
         }
-      } else {
-        throw Error(JSON.stringify(error));
-      }
-    } catch (e) {
-      if (retry) {
-        core.info(`Error in starting local tunnel. Trying again...`);
-        await this.startBinary(retry - 1);
-      } else {
-        throw Error(`Local tunnel could not be started. Error message from binary: ${e.message}`);
+      } catch (e) {
+        if (triesAvailable) {
+          core.info(`Error in starting local tunnel: ${e.message}. Trying again...`);
+        } else {
+          throw Error(`Local tunnel could not be started. Error message from binary: ${e.message}`);
+        }
       }
     }
   }

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -152,8 +152,8 @@ class BinaryControl {
       core.info('BrowserStackLocal binary already exists in cache. Using that instead of downloading again...');
       // A cached tool is persisted across runs. But the PATH is reset back to its original
       // state between each run. Thus, adding the cached tool path back to PATH again.
-      core.addPath(cachedBinaryPath);
-      return;
+      // core.addPath(cachedBinaryPath);
+      // return;
     }
 
     try {
@@ -204,7 +204,9 @@ class BinaryControl {
         }
       } catch (e) {
         if (triesAvailable) {
-          core.info(`Error in starting local tunnel: ${e.message}. Trying again...`);
+          core.info(`Error in starting local tunnel: ${e.message}. Trying again in 5 seconds...`);
+          // eslint-disable-next-line no-await-in-loop
+          await Utils.sleepFor(5000);
         } else {
           throw Error(`Local tunnel could not be started. Error message from binary: ${e.message}`);
         }

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -43,18 +43,23 @@ class BinaryControl {
    * platform and the architecture
    */
   _decidePlatformAndBinary() {
+    this.binaryFolder = path.resolve(
+      process.env.GITHUB_WORKSPACE,
+      '..', '..', '..',
+      '_work',
+      'binary',
+      LOCAL_BINARY_FOLDER,
+      this.platform,
+    );
     switch (this.platform) {
       case PLATFORMS.DARWIN:
         this.binaryLink = BINARY_LINKS.DARWIN;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.LINUX:
         this.binaryLink = os.arch() === 'x32' ? BINARY_LINKS.LINUX_32 : BINARY_LINKS.LINUX_64;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.WIN32:
         this.binaryLink = BINARY_LINKS.WINDOWS;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       default:
         throw Error(`Unsupported Platform: ${this.platform}. No BrowserStackLocal binary found.`);
@@ -173,8 +178,8 @@ class BinaryControl {
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
       core.info(`Downloaded Path: ${downloadPath}`);
-      // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
-      // core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
+      const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
+      core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
       // core.addPath(cachedPath);
     } catch (e) {

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -152,7 +152,7 @@ class BinaryControl {
     }
     try {
       await this._makeDirectory();
-      core.info('Deleting any existing partially downloaded binary...');
+      core.info('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary from the download path...');
       const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
       const previousLocalBinary = path.resolve(this.binaryFolder, LOCAL_BINARY_NAME);
       await Promise.all([io.rmRF(binaryZip), io.rmRF(previousLocalBinary)]);

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -168,7 +168,7 @@ class BinaryControl {
     try {
       await this._makeDirectory();
       core.debug('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary before downloading...');
-      // this._removeAnyStaleBinary();
+      this._removeAnyStaleBinary();
 
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -153,7 +153,9 @@ class BinaryControl {
     try {
       await this._makeDirectory();
       core.info('Downloading BrowserStackLocal binary...');
-      const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
+      const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
+      await io.rmRF(binaryZip);
+      const downloadPath = await tc.downloadTool(this.binaryLink, binaryZip);
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -173,7 +173,7 @@ class BinaryControl {
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
       // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
-      core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
+      // core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
       // core.addPath(cachedPath);
     } catch (e) {

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -146,10 +146,13 @@ class BinaryControl {
    * Downloads the Local Binary, extracts it and adds it in the PATH variable
    */
   async downloadBinary() {
-    if (Utils.checkToolInCache(LOCAL_BINARY_NAME)) {
+    const cachedBinaryPath = Utils.checkToolInCache(LOCAL_BINARY_NAME, '1.0.0');
+    if (cachedBinaryPath) {
       core.info('BrowserStackLocal binary already exists in cache. Using that instead of downloading again...');
-      // return;
+      core.addPath(cachedBinaryPath);
+      return;
     }
+
     try {
       await this._makeDirectory();
       core.info('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary from the download path...');
@@ -163,7 +166,6 @@ class BinaryControl {
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
       core.addPath(cachedPath);
-      this.binaryPath = extractedPath;
     } catch (e) {
       throw Error(`BrowserStackLocal binary could not be downloaded due to ${e.message}`);
     }

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -46,15 +46,15 @@ class BinaryControl {
     switch (this.platform) {
       case PLATFORMS.DARWIN:
         this.binaryLink = BINARY_LINKS.DARWIN;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.LINUX:
         this.binaryLink = os.arch() === 'x32' ? BINARY_LINKS.LINUX_32 : BINARY_LINKS.LINUX_64;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       case PLATFORMS.WIN32:
         this.binaryLink = BINARY_LINKS.WINDOWS;
-        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
+        this.binaryFolder = path.resolve(process.env.GITHUB_WORKSPACE, '..', '..', '..', '_work', 'binary', LOCAL_BINARY_FOLDER, this.platform);
         break;
       default:
         throw Error(`Unsupported Platform: ${this.platform}. No BrowserStackLocal binary found.`);

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -160,7 +160,10 @@ class BinaryControl {
       await this._makeDirectory();
       core.info('BrowserStackLocal binary not found in cache. Deleting any stale/existing binary from the download path...');
       const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
-      const previousLocalBinary = path.resolve(this.binaryFolder, LOCAL_BINARY_NAME);
+      const previousLocalBinary = path.resolve(
+        this.binaryFolder,
+        `${LOCAL_BINARY_NAME}${this.platform === PLATFORMS.WIN32 ? '.exe' : ''}`
+      );
       await Promise.all([io.rmRF(binaryZip), io.rmRF(previousLocalBinary)]);
 
       core.info('Downloading BrowserStackLocal binary...');

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -15,6 +15,7 @@ const {
   LOCAL_BINARY_FOLDER,
   PLATFORMS,
   LOCAL_BINARY_NAME,
+  LOCAL_BINARY_ZIP,
   LOCAL_LOG_FILE_PREFIX,
   LOCAL_BINARY_TRIGGER,
   BINARY_MAX_TRIES,
@@ -149,7 +150,7 @@ class BinaryControl {
   }
 
   async _removeAnyStaleBinary() {
-    const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
+    const binaryZip = path.resolve(this.binaryFolder, LOCAL_BINARY_ZIP);
     const previousLocalBinary = path.resolve(
       this.binaryFolder,
       `${LOCAL_BINARY_NAME}${this.platform === PLATFORMS.WIN32 ? '.exe' : ''}`,
@@ -176,7 +177,10 @@ class BinaryControl {
       this._removeAnyStaleBinary();
 
       core.info('Downloading BrowserStackLocal binary...');
-      const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
+      const downloadPath = await tc.downloadTool(
+        this.binaryLink,
+        path.resolve(this.binaryFolder, LOCAL_BINARY_ZIP),
+      );
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -173,8 +173,8 @@ class BinaryControl {
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
       core.info(`Downloaded Path: ${downloadPath}`);
-      // const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
-      // core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
+      const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
+      core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       // const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');
       // core.addPath(cachedPath);
     } catch (e) {

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -152,9 +152,10 @@ class BinaryControl {
     }
     try {
       await this._makeDirectory();
-      core.info('Downloading BrowserStackLocal binary...');
+      core.info('Deleting any existing partially downloaded binary...');
       const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
       await io.rmRF(binaryZip);
+      core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, binaryZip);
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -154,7 +154,9 @@ class BinaryControl {
       await this._makeDirectory();
       core.info('Deleting any existing partially downloaded binary...');
       const binaryZip = path.resolve(this.binaryFolder, 'binaryZip');
-      await io.rmRF(binaryZip);
+      const previousLocalBinary = path.resolve(this.binaryFolder, LOCAL_BINARY_NAME);
+      await Promise.all([io.rmRF(binaryZip), io.rmRF(previousLocalBinary)]);
+
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, binaryZip);
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -127,20 +127,20 @@ class BinaryControl {
   async _triggerBinary(operation) {
     let triggerOutput = '';
     let triggerError = '';
-    await exec.exec(
-      `${LOCAL_BINARY_NAME} ${this.binaryArgs} --daemon ${operation}`,
-      [],
-      {
-        listeners: {
-          stdout: (data) => {
-            triggerOutput += data.toString();
-          },
-          stderr: (data) => {
-            triggerError += data.toString();
-          },
-        },
-      },
-    );
+    // await exec.exec(
+    //   `${LOCAL_BINARY_NAME} ${this.binaryArgs} --daemon ${operation}`,
+    //   [],
+    //   {
+    //     listeners: {
+    //       stdout: (data) => {
+    //         triggerOutput += data.toString();
+    //       },
+    //       stderr: (data) => {
+    //         triggerError += data.toString();
+    //       },
+    //     },
+    //   },
+    // );
 
     return {
       output: triggerOutput,

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -43,7 +43,6 @@ class BinaryControl {
    * platform and the architecture
    */
   _decidePlatformAndBinary() {
-    core.info(`GITHUB WORKSPACE CHECK: ${process.env.GITHUB_WORKSPACE}`);
     this.binaryFolder = path.resolve(
       process.env.GITHUB_WORKSPACE,
       '..', '..', '..',
@@ -178,7 +177,6 @@ class BinaryControl {
 
       core.info('Downloading BrowserStackLocal binary...');
       const downloadPath = await tc.downloadTool(this.binaryLink, path.resolve(this.binaryFolder, 'binaryZip'));
-      core.info(`Downloaded Path: ${downloadPath}`);
       const extractedPath = await tc.extractZip(downloadPath, this.binaryFolder);
       core.info(`BrowserStackLocal binary downloaded & extracted successfuly at: ${extractedPath}`);
       const cachedPath = await tc.cacheDir(extractedPath, LOCAL_BINARY_NAME, '1.0.0');

--- a/setup-local/src/utils/index.js
+++ b/setup-local/src/utils/index.js
@@ -9,6 +9,7 @@ class Utils {
 
   static checkToolInCache(toolName) {
     const toolCache = tc.findAllVersions(toolName);
+    console.dir(process.env.PATH);
     console.dir(toolCache);
     return toolCache.length !== 0;
   }

--- a/setup-local/src/utils/index.js
+++ b/setup-local/src/utils/index.js
@@ -13,7 +13,9 @@ class Utils {
   }
 
   static async sleepFor(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    let parsedMilliseconds = parseFloat(ms);
+    parsedMilliseconds = parsedMilliseconds > 0 ? parsedMilliseconds : 0;
+    return new Promise((resolve) => setTimeout(resolve, parsedMilliseconds));
   }
 }
 

--- a/setup-local/src/utils/index.js
+++ b/setup-local/src/utils/index.js
@@ -9,8 +9,6 @@ class Utils {
 
   static checkToolInCache(toolName, version) {
     const toolCachePath = tc.find(toolName, version);
-    console.dir(process.env.PATH);
-    console.dir(toolCachePath);
     return toolCachePath;
   }
 }

--- a/setup-local/src/utils/index.js
+++ b/setup-local/src/utils/index.js
@@ -11,6 +11,10 @@ class Utils {
     const toolCachePath = tc.find(toolName, version);
     return toolCachePath;
   }
+
+  static async sleepFor(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
 }
 
 module.exports = Utils;

--- a/setup-local/src/utils/index.js
+++ b/setup-local/src/utils/index.js
@@ -10,7 +10,7 @@ class Utils {
   static checkToolInCache(toolName, version) {
     const toolCachePath = tc.find(toolName, version);
     console.dir(process.env.PATH);
-    console.dir(toolCache);
+    console.dir(toolCachePath);
     return toolCachePath;
   }
 }

--- a/setup-local/src/utils/index.js
+++ b/setup-local/src/utils/index.js
@@ -9,6 +9,7 @@ class Utils {
 
   static checkToolInCache(toolName) {
     const toolCache = tc.findAllVersions(toolName);
+    console.dir(toolCache);
     return toolCache.length !== 0;
   }
 }

--- a/setup-local/src/utils/index.js
+++ b/setup-local/src/utils/index.js
@@ -7,11 +7,11 @@ class Utils {
     delete process.env[environmentVariable];
   }
 
-  static checkToolInCache(toolName) {
-    const toolCache = tc.findAllVersions(toolName);
+  static checkToolInCache(toolName, version) {
+    const toolCachePath = tc.find(toolName, version);
     console.dir(process.env.PATH);
     console.dir(toolCache);
-    return toolCache.length !== 0;
+    return toolCachePath;
   }
 }
 

--- a/setup-local/test/binaryControl.test.js
+++ b/setup-local/test/binaryControl.test.js
@@ -385,6 +385,7 @@ describe('Binary Control Operations', () => {
       });
 
       it('Delete any stale local binary (non windows)', () => {
+        binaryControl.platform = PLATFORMS.DARWIN;
         binaryControl._removeAnyStaleBinary();
         const binaryZipPath = path.resolve(binaryControl.binaryFolder, 'binaryZip');
         const staleBinaryPath = path.resolve(

--- a/setup-local/test/binaryControl.test.js
+++ b/setup-local/test/binaryControl.test.js
@@ -18,6 +18,7 @@ const {
   LOCAL_BINARY_FOLDER,
   PLATFORMS,
   LOCAL_BINARY_NAME,
+  LOCAL_BINARY_ZIP,
   LOCAL_LOG_FILE_PREFIX,
   LOCAL_BINARY_TRIGGER,
   ALLOWED_INPUT_VALUES: {
@@ -387,7 +388,7 @@ describe('Binary Control Operations', () => {
       it('Delete any stale local binary (non windows)', () => {
         binaryControl.platform = PLATFORMS.DARWIN;
         binaryControl._removeAnyStaleBinary();
-        const binaryZipPath = path.resolve(binaryControl.binaryFolder, 'binaryZip');
+        const binaryZipPath = path.resolve(binaryControl.binaryFolder, LOCAL_BINARY_ZIP);
         const staleBinaryPath = path.resolve(
           binaryControl.binaryFolder,
           `${LOCAL_BINARY_NAME}`,
@@ -399,7 +400,7 @@ describe('Binary Control Operations', () => {
       it('Delete any stale local binary (windows)', () => {
         binaryControl.platform = PLATFORMS.WIN32;
         binaryControl._removeAnyStaleBinary();
-        const binaryZipPath = path.resolve(binaryControl.binaryFolder, 'binaryZip');
+        const binaryZipPath = path.resolve(binaryControl.binaryFolder, LOCAL_BINARY_ZIP);
         const staleBinaryPath = path.resolve(
           binaryControl.binaryFolder,
           `${LOCAL_BINARY_NAME}.exe`,

--- a/setup-local/test/binaryControl.test.js
+++ b/setup-local/test/binaryControl.test.js
@@ -40,25 +40,33 @@ describe('Binary Control Operations', () => {
   });
 
   context('Private Methods Behaviour', () => {
+    before(() => {
+      process.env.GITHUB_WORKSPACE = '/some/work/space';
+    });
+
+    after(() => {
+      process.env.GITHUB_WORKSPACE = '';
+    });
+
     const platformAndBinary = [
       {
         binary: BINARY_LINKS.DARWIN,
-        folder: `/work/binary/${LOCAL_BINARY_FOLDER}/darwin`,
+        folder: `/_work/binary/${LOCAL_BINARY_FOLDER}/darwin`,
         arch: 'x64',
         platform: PLATFORMS.DARWIN,
       }, {
         binary: BINARY_LINKS.LINUX_32,
-        folder: `/work/binary/${LOCAL_BINARY_FOLDER}/linux`,
+        folder: `/_work/binary/${LOCAL_BINARY_FOLDER}/linux`,
         arch: 'x32',
         platform: PLATFORMS.LINUX,
       }, {
         binary: BINARY_LINKS.LINUX_64,
-        folder: `/work/binary/${LOCAL_BINARY_FOLDER}/linux`,
+        folder: `/_work/binary/${LOCAL_BINARY_FOLDER}/linux`,
         arch: 'x64',
         platform: PLATFORMS.LINUX,
       }, {
         binary: BINARY_LINKS.WINDOWS,
-        folder: `/work/binary/${LOCAL_BINARY_FOLDER}/win32`,
+        folder: `/_work/binary/${LOCAL_BINARY_FOLDER}/win32`,
         arch: 'x32',
         platform: PLATFORMS.WIN32,
       },
@@ -91,18 +99,22 @@ describe('Binary Control Operations', () => {
 
     it('Makes Directory for the binary folder in recursive manner', async () => {
       sinon.stub(io, 'mkdirP').returns(true);
-      sinon.stub(os, 'platform').returns('darwin');
       const binaryControl = new BinaryControl();
       await binaryControl._makeDirectory();
-      sinon.assert.calledWith(io.mkdirP, path.resolve(process.env.HOME, 'work', 'binary', LOCAL_BINARY_FOLDER, 'darwin'));
+      sinon.assert.calledWith(io.mkdirP, path.resolve(
+        process.env.GITHUB_WORKSPACE,
+        '..', '..', '..',
+        '_work',
+        'binary',
+        LOCAL_BINARY_FOLDER,
+        os.platform(),
+      ));
       io.mkdirP.restore();
-      os.platform.restore();
     });
 
     context('Log File metadata', () => {
       beforeEach(() => {
         sinon.stub(core, 'exportVariable');
-        sinon.stub(os, 'platform').returns('darwin');
         sinon.stub(github, 'context').value({
           job: 'someJobName',
         });
@@ -111,13 +123,22 @@ describe('Binary Control Operations', () => {
       afterEach(() => {
         delete process.env[BROWSERSTACK_LOCAL_LOGS_FILE];
         core.exportVariable.restore();
-        os.platform.restore();
       });
 
       it('Generates log-file name and path for Binary', () => {
         sinon.stub(Date, 'now').returns('now');
         const expectedLogFileName = `${LOCAL_LOG_FILE_PREFIX}_${github.context.job}_now.log`;
-        const expectedLogFilePath = path.resolve(path.resolve(process.env.HOME, 'work', 'binary', LOCAL_BINARY_FOLDER, 'darwin'), expectedLogFileName);
+        const expectedLogFilePath = path.resolve(
+          path.resolve(
+            process.env.GITHUB_WORKSPACE,
+            '..', '..', '..',
+            '_work',
+            'binary',
+            LOCAL_BINARY_FOLDER,
+            os.platform(),
+          ),
+          expectedLogFileName,
+        );
         const binaryControl = new BinaryControl();
         binaryControl._generateLogFileMetadata();
         expect(binaryControl.logFileName).to.eq(expectedLogFileName);
@@ -133,7 +154,17 @@ describe('Binary Control Operations', () => {
       it('Fetches log-file name and generates path for Binary if logs file name was already defined', () => {
         process.env[BROWSERSTACK_LOCAL_LOGS_FILE] = `${LOCAL_LOG_FILE_PREFIX}_${github.context.job}_now.log`;
         const expectedLogFileName = `${LOCAL_LOG_FILE_PREFIX}_${github.context.job}_now.log`;
-        const expectedLogFilePath = path.resolve(path.resolve(process.env.HOME, 'work', 'binary', LOCAL_BINARY_FOLDER, 'darwin'), expectedLogFileName);
+        const expectedLogFilePath = path.resolve(
+          path.resolve(
+            process.env.GITHUB_WORKSPACE,
+            '..', '..', '..',
+            '_work',
+            'binary',
+            LOCAL_BINARY_FOLDER,
+            os.platform(),
+          ),
+          expectedLogFileName,
+        );
         const binaryControl = new BinaryControl();
         binaryControl._generateLogFileMetadata();
         expect(binaryControl.logFileName).to.eq(expectedLogFileName);
@@ -148,18 +179,18 @@ describe('Binary Control Operations', () => {
 
     context('Generates args string based on the input to Binary Control & the operation required, i.e. start/stop', () => {
       beforeEach(() => {
-        sinon.stub(os, 'platform').returns('darwin');
         sinon.stub(github, 'context').value({
           job: 'someJobName',
         });
         sinon.stub(Date, 'now').returns('now');
         sinon.stub(core, 'exportVariable');
+        process.env.GITHUB_WORKSPACE = '/some/work/space';
       });
 
       afterEach(() => {
-        os.platform.restore();
         Date.now.restore();
         core.exportVariable.restore();
+        process.env.GITHUB_WORKSPACE = '';
       });
 
       context('Start Operation', () => {
@@ -172,7 +203,16 @@ describe('Binary Control Operations', () => {
             localTesting: 'start',
           };
 
-          const expectedFinalArgs = `--key someKey --only-automate --ci-plugin GitHubAction --arg1 val1 --arg2 val2 --local-identifier someIdentifier --verbose 1 --log-file ${path.resolve(process.env.HOME, 'work', 'binary', 'LocalBinaryFolder', 'darwin', 'BrowserStackLocal_someJobName_now.log')} `;
+          const expectedLogFilePath = path.resolve(
+            process.env.GITHUB_WORKSPACE,
+            '..', '..', '..',
+            '_work',
+            'binary',
+            'LocalBinaryFolder',
+            os.platform(),
+            'BrowserStackLocal_someJobName_now.log',
+          );
+          const expectedFinalArgs = `--key someKey --only-automate --ci-plugin GitHubAction --arg1 val1 --arg2 val2 --local-identifier someIdentifier --verbose 1 --log-file ${expectedLogFilePath} `;
           const binaryControl = new BinaryControl(stateForBinary);
           binaryControl._generateArgsForBinary();
           expect(binaryControl.binaryArgs).to.eq(expectedFinalArgs);

--- a/setup-local/test/binaryControl.test.js
+++ b/setup-local/test/binaryControl.test.js
@@ -21,6 +21,7 @@ const {
   LOCAL_BINARY_ZIP,
   LOCAL_LOG_FILE_PREFIX,
   LOCAL_BINARY_TRIGGER,
+  RETRY_DELAY_BINARY,
   ALLOWED_INPUT_VALUES: {
     LOCAL_TESTING,
   },
@@ -509,7 +510,7 @@ describe('Binary Control Operations', () => {
           try {
             await binaryControl.startBinary();
           } catch (e) {
-            sinon.assert.calledWith(Utils.sleepFor, 5000);
+            sinon.assert.calledWith(Utils.sleepFor, RETRY_DELAY_BINARY);
             sinon.assert.calledWith(core.info, 'Error in starting local tunnel: "some message". Trying again in 5 seconds...');
             expect(e.message).to.eq('Local tunnel could not be started. Error message from binary: "some message"');
           }
@@ -529,7 +530,7 @@ describe('Binary Control Operations', () => {
           try {
             await binaryControl.startBinary();
           } catch (e) {
-            sinon.assert.calledWith(Utils.sleepFor, 5000);
+            sinon.assert.calledWith(Utils.sleepFor, RETRY_DELAY_BINARY);
             sinon.assert.calledWith(core.info, `Error in starting local tunnel: ${JSON.stringify(response.error)}. Trying again in 5 seconds...`);
             expect(e.message).to.eq(`Local tunnel could not be started. Error message from binary: ${JSON.stringify(response.error)}`);
           }

--- a/setup-local/test/binaryControl.test.js
+++ b/setup-local/test/binaryControl.test.js
@@ -405,13 +405,11 @@ describe('Binary Control Operations', () => {
         binaryControl = new BinaryControl();
         sinon.stub(binaryControl, '_generateArgsForBinary').returns(true);
         sinon.stub(core, 'info');
-        sinon.stub(core, 'debug');
         sinon.stub(Utils, 'sleepFor');
       });
 
       afterEach(() => {
         core.info.restore();
-        core.debug.restore();
         Utils.sleepFor.restore();
       });
 
@@ -470,7 +468,7 @@ describe('Binary Control Operations', () => {
             await binaryControl.startBinary();
           } catch (e) {
             sinon.assert.calledWith(Utils.sleepFor, 5000);
-            sinon.assert.calledWith(core.debug, 'Error in starting local tunnel: "some message". Trying again in 5 seconds...');
+            sinon.assert.calledWith(core.info, 'Error in starting local tunnel: "some message". Trying again in 5 seconds...');
             expect(e.message).to.eq('Local tunnel could not be started. Error message from binary: "some message"');
           }
         });
@@ -490,7 +488,7 @@ describe('Binary Control Operations', () => {
             await binaryControl.startBinary();
           } catch (e) {
             sinon.assert.calledWith(Utils.sleepFor, 5000);
-            sinon.assert.calledWith(core.debug, `Error in starting local tunnel: ${JSON.stringify(response.error)}. Trying again in 5 seconds...`);
+            sinon.assert.calledWith(core.info, `Error in starting local tunnel: ${JSON.stringify(response.error)}. Trying again in 5 seconds...`);
             expect(e.message).to.eq(`Local tunnel could not be started. Error message from binary: ${JSON.stringify(response.error)}`);
           }
         });

--- a/setup-local/test/binaryControl.test.js
+++ b/setup-local/test/binaryControl.test.js
@@ -385,9 +385,9 @@ describe('Binary Control Operations', () => {
         binaryControl._removeAnyStaleBinary.restore();
       });
 
-      it('Delete any stale local binary (non windows)', () => {
+      it('Delete any stale local binary (non windows)', async () => {
         binaryControl.platform = PLATFORMS.DARWIN;
-        binaryControl._removeAnyStaleBinary();
+        await binaryControl._removeAnyStaleBinary();
         const binaryZipPath = path.resolve(binaryControl.binaryFolder, LOCAL_BINARY_ZIP);
         const staleBinaryPath = path.resolve(
           binaryControl.binaryFolder,
@@ -397,9 +397,9 @@ describe('Binary Control Operations', () => {
         sinon.assert.calledWith(io.rmRF, staleBinaryPath);
       });
 
-      it('Delete any stale local binary (windows)', () => {
+      it('Delete any stale local binary (windows)', async () => {
         binaryControl.platform = PLATFORMS.WIN32;
-        binaryControl._removeAnyStaleBinary();
+        await binaryControl._removeAnyStaleBinary();
         const binaryZipPath = path.resolve(binaryControl.binaryFolder, LOCAL_BINARY_ZIP);
         const staleBinaryPath = path.resolve(
           binaryControl.binaryFolder,

--- a/setup-local/test/utils/index.test.js
+++ b/setup-local/test/utils/index.test.js
@@ -17,18 +17,56 @@ describe('Utils', () => {
   });
 
   context('Check if tool exists in cache', () => {
-    it('Returns true if tool exists in cache', () => {
-      sinon.stub(tc, 'findAllVersions').returns(['somePath']);
-      expect(Utils.checkToolInCache('someTool')).to.eq(true);
-      sinon.assert.calledWith(tc.findAllVersions, 'someTool');
-      tc.findAllVersions.restore();
+    it('Returns the path if tool exists in cache', () => {
+      sinon.stub(tc, 'find').returns('some/path');
+      expect(Utils.checkToolInCache('someTool', 'version')).to.eq('some/path');
+      sinon.assert.calledWith(tc.find, 'someTool', 'version');
+      tc.find.restore();
     });
 
-    it("Returns false if tool doesn't exists in cache", () => {
-      sinon.stub(tc, 'findAllVersions').returns([]);
-      expect(Utils.checkToolInCache('someTool')).to.eq(false);
-      sinon.assert.calledWith(tc.findAllVersions, 'someTool');
-      tc.findAllVersions.restore();
+    it("Returns empty string if tool doesn't exists in cache", () => {
+      sinon.stub(tc, 'find').returns('');
+      expect(Utils.checkToolInCache('someTool', 'version')).to.eq('');
+      sinon.assert.calledWith(tc.find, 'someTool', 'version');
+      tc.find.restore();
+    });
+  });
+
+  context('SleepFor', () => {
+    it('Sleeps for given milliseconds', (done) => {
+      const fakeTimer = sinon.useFakeTimers();
+      const startTime = Date.now();
+      Utils.sleepFor(5000)
+        .then(() => {
+          expect(Date.now() - startTime).to.eq(5000);
+          fakeTimer.restore();
+          done();
+        });
+      fakeTimer.tick(5000);
+    });
+
+    it('Sleeps for 0 milliseconds if the value is NaN', (done) => {
+      const fakeTimer = sinon.useFakeTimers();
+      const startTime = Date.now();
+      Utils.sleepFor("Not a Number")
+        .then(() => {
+          expect(Date.now() - startTime).to.eq(0);
+          fakeTimer.restore();
+          done();
+        });
+      fakeTimer.tick(0);
+    });
+
+    it('Sleeps for 0 milliseconds if the value is <= 0', (done) => {
+      const fakeTimer = sinon.useFakeTimers();
+      const startTime = Date.now();
+      Utils.sleepFor(-10)
+        .then(() => {
+          expect(Date.now() - startTime).to.eq(0);
+          fakeTimer.restore();
+          done();
+        });
+      fakeTimer.tick(0);
     });
   });
 });


### PR DESCRIPTION
Fixes:
1. Self-hosted runner's caching of binary issues fixed.
2. Retries in starting binary since there are chances that it fails for the first time (windows).
3. Unit tests for the same.

Somewhat similar issues:
1. https://github.com/browserstack/browserstack-local-csharp/issues/14
2. https://github.com/zalando/zalenium/issues/452

Thus, having retry irrespective of OS can help mitigate such issues.