### PR TITLE
add: branding logo and color for marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,3 +16,6 @@ inputs:
 runs:
   using: 'node12'
   main: 'setup-env/dist/index.js'
+branding:
+  icon: 'check-circle'
+  color: 'green'


### PR DESCRIPTION
Adds a `check-circle` logo in green colour for branding. Mandatory to have these fields before publishing.

![image](https://user-images.githubusercontent.com/22256912/91465428-646ae480-e8ab-11ea-8b5f-e49b87221d64.png)

Reference: https://feathericons.com/?query=check-circle