### PR TITLE
feat: truncate build info commit message to 200chars

### DIFF
--- a/setup-env/src/actionInput/inputValidator.js
+++ b/setup-env/src/actionInput/inputValidator.js
@@ -33,7 +33,8 @@ class InputValidator {
 
         const probableBranchOrTag = ref.split('/').pop();
         const slicedSHA = commitSHA.slice(0, 7);
-        return `[${probableBranchOrTag}] Commit ${slicedSHA}: ${commitMessage} [Workflow: ${workflowNumber}]`;
+        const slicedCommitMessage = commitMessage.slice(0,200);
+        return `[${probableBranchOrTag}] Commit ${slicedSHA}: ${slicedCommitMessage} [Workflow: ${workflowNumber}]`;
       }
       case 'pull_request': {
         const {

--- a/setup-env/test/actionInput/inputValidator.test.js
+++ b/setup-env/test/actionInput/inputValidator.test.js
@@ -89,6 +89,27 @@ describe('InputValidator class to validate individual fields of the action input
         });
       });
 
+      context('Push event with long commit message', () => {
+        beforeEach(() => {
+          sinon.stub(github, 'context').value({
+            payload: {
+              head_commit: {
+                message: 'messageOfHeadCommit Lorem ipsum dolor sit amet, nonummy ligula volutpat hac integer nonummy. Suspendisse ultricies, congue etiam tellus, erat libero, nulla eleifend, mauris pellentesque. Suspendisse integer praesent vel, integer gravida mauris, fringilla vehicula lacinia non',
+              },
+            },
+            sha: 'someSHA',
+            runNumber: 123,
+            ref: 'refs/head/branchOrTagName',
+            eventName: 'push',
+          });
+        });
+
+        it('Generate build info with commit information', () => {
+          const expectedValue = '[branchOrTagName] Commit someSHA: messageOfHeadCommit Lorem ipsum dolor sit amet, nonummy ligula volutpat hac integer nonummy. Suspendisse ultricies, congue etiam tellus, erat libero, nulla eleifend, mauris pellentesque. Suspendisse  [Workflow: 123]';
+          expect(InputValidator._getBuildInfo()).to.eq(expectedValue);
+        });
+      });
+
       context('Pull Request event', () => {
         beforeEach(() => {
           sinon.stub(github, 'context').value({


### PR DESCRIPTION
* the generated value for `BROWSERSTACK_BUILD_NAME` must be [up to 255 characters](https://www.browserstack.com/docs/automate/selenium/organize-tests)
* truncating this to 200 characters leaves up to 55 characters for branch name, SHA, etc, which seems sufficient
* fix https://github.com/browserstack/github-actions/issues/13 
