### PR TITLE
Update binary install area to RUNNER_TOOL_CACHE

### DIFF
--- a/setup-local/dist/index.js
+++ b/setup-local/dist/index.js
@@ -1111,7 +1111,7 @@ class BinaryControl {
    */
   _decidePlatformAndBinary() {
     this.binaryFolder = path.resolve(
-      process.env.GITHUB_WORKSPACE,
+      process.env.RUNNER_TOOL_CACHE,
       '..', '..', '..',
       '_work',
       'binary',

--- a/setup-local/src/binaryControl.js
+++ b/setup-local/src/binaryControl.js
@@ -46,7 +46,7 @@ class BinaryControl {
    */
   _decidePlatformAndBinary() {
     this.binaryFolder = path.resolve(
-      process.env.GITHUB_WORKSPACE,
+      process.env.RUNNER_TOOL_CACHE,
       '..', '..', '..',
       '_work',
       'binary',


### PR DESCRIPTION
the GITHUB_WORKSPACE location is protected in custom action runners, moving the install location to a less protected directory like RUNNER_TOOL_CACHE removes that issue